### PR TITLE
Add conditional to prerm script to fix apt-get remove uhd error

### DIFF
--- a/host/cmake/debian/prerm.in
+++ b/host/cmake/debian/prerm.in
@@ -18,6 +18,8 @@
 
 if [ "$1" = "remove" ]; then
     echo 'Uninstalling UHD.'
-    rm /etc/udev/rules.d/uhd-usrp.rules
-    udevadm control --reload-rules
+    if [ -f /etc/udev/rules.d/uhd-usrp.rules ]; then
+        rm /etc/udev/rules.d/uhd-usrp.rules
+        udevadm control --reload-rules
+    fi
 fi


### PR DESCRIPTION
@JoelSpark

This is the fix needed, but we'll need to build and update the debian package in apt.pvt.spire.com.